### PR TITLE
Fix broken JSON

### DIFF
--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/RobTillaart/SHT31",
+    "url": "https://github.com/RobTillaart/SHT31"
   },
   "version":"0.2.5",
   "frameworks": "arduino",


### PR DESCRIPTION
@RobTillaart could you increment a patch version in both `library.json` and `library.properties` to 0.2.6 and tag the 0.2.6 release?

Thanks!

https://community.platformio.org/t/sht-library-has-tags-up-to-0-2-5-but-pio-only-gets-0-2-1/18198